### PR TITLE
A friendlier readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-Source code can be found in the `*src*` asset(s).
+# Welcome to our Trial Release Archive!
+
+## This is some awesome stuff we have for you
+
+Marketing copy about how great we are. Marketing copy about how great we are. Marketing copy about how great we are. Marketing copy about how great we are. Marketing copy about how great we are. 
+
+Now, if you're an apple-head, use [this file](https://github.com/christiam/alpha-releases/releases/download/v2.8.0-alpha/ncbi-blast-2.8.0.dmg) to install. (Checksum for the cautious is [here](https://github.com/christiam/alpha-releases/releases/download/v2.8.0-alpha/ncbi-blast-2.8.0.dmg.md5).
+
+But if you love all things Gatesian, try [this one](#). [checksum](#).
+
+Finally, open-source-OSers take heart!  We've got you covered [here](#). [checksum](#).
+
+Check out our awesome documentation [here (link to docs or main site)](#).
+
+Or, browse the whole list of release files [here](https://github.com/christiam/alpha-releases/releases/tag/v2.8.0-alpha).
+
+Have fun!


### PR DESCRIPTION
Check this out.  Friendlier - this way you point people to the repo itself, and they see the Readme right away.  You don't really have to link to the 'releases' page at all.